### PR TITLE
Update gcloud sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV GOOGLE_CLOUD_SDK_VERSION=145.0.0
+ENV GOOGLE_CLOUD_SDK_VERSION=150.0.0
 ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.48
 ENV CLOUDSDK_APP_RUNTIME_ROOT=/google-cloud-sdk/platform/ext-runtime/
 RUN apk add --no-cache curl python


### PR DESCRIPTION
Updates from SDK 145.0.0 to 150.0.0. According to https://cloud.google.com/sdk/docs/release-notes there have been no breaking changes since for App Engine