### PR TITLE
upgrade to 0.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ To see a full list of configuration settings for the project, check out the [GAE
 
 This is currently using `gcloud` version `145.0.0` and App Engine SDK version `1.9.48`.
 
+### Drone versions
+
+This plugin supports Drone 0.4 and 0.6+ (0.5 is deprecated).
+
+The examples below are for secrets in the 0.4 format, where the GCP Service Account json must be passed to the `token` parameter in .drone.yml, using the `$$SECRET_NAME` notation.
+
+For Drone 0.6+, the plugin expects credentials in the `GAE_CREDENTIALS` environment variable. See the [official documentation](http://docs.drone.io/manage-secrets/). Either: 
+  - Name the secret `GAE_CREDENTIALS` and inlclude it in the `secrets` block, or
+  - follow "Alternate Names" in the doc, setting the `target` to `GAE_CREDENTIALS`.
+
 ## Examples
 
 ### Basic example of capable of deploying a new version of a Go, PHP and Python 'hello, world' application to standard App Engine.

--- a/exec.go
+++ b/exec.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
+	"strings"
 )
+
+var reRedact = regexp.MustCompile(`(oauth2_access_token)\s+\S+\s+`)
 
 type Environ struct {
 	dir    string
@@ -23,6 +28,8 @@ func NewEnviron(dir string, env []string, stdout, stderr io.Writer) *Environ {
 
 // Run executes the given program.
 func (e *Environ) Run(name string, arg ...string) error {
+	displayArg := reRedact.ReplaceAll([]byte(strings.Trim(fmt.Sprint(arg), "[]")), []byte("$1 [redacted] "))
+	fmt.Printf("Running Command: %s %s\n", name, displayArg)
 	cmd := exec.Command(name, arg...)
 	cmd.Dir = e.dir
 	cmd.Env = e.env

--- a/main.go
+++ b/main.go
@@ -90,7 +90,6 @@ func wrapMain() error {
 	}
 
 	fmt.Printf("Drone GAE Plugin built from %s\n", rev)
-	fmt.Println(os.Environ())
 
 	vargs := GAE{}
 	workspace := ""
@@ -167,7 +166,7 @@ func configFromStdin(vargs *GAE, workspace *string) error {
 	return nil
 }
 
-// GAE struct has different json for these, so use an intermediate
+// GAE struct has different json for these, so use an intermediate for the new drone format
 type dummyGAE struct {
 	AddlArgs map[string]string `json:"-"`
 	AEEnv    map[string]string `json:"-"`
@@ -225,9 +224,9 @@ func validateVargs(vargs *GAE) error {
 
 	if vargs.Project == "" {
 		vargs.Project = getProjectFromToken(vargs.Token)
-	}
-	if vargs.Project == "" {
-		return fmt.Errorf("project id not found in token or param")
+		if vargs.Project == "" {
+			return fmt.Errorf("project id not found in token or param")
+		}
 	}
 
 	if vargs.Action == "" {

--- a/main.go
+++ b/main.go
@@ -178,15 +178,22 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 	// drone plugin input format du jour:
 	// http://readme.drone.io/plugins/plugin-parameters/
 
-	// corresponds to `project: xxx` parameter in drone config
+	// Strings
 	vargs.Project = os.Getenv("PLUGIN_PROJECT")
 	vargs.Action = os.Getenv("PLUGIN_ACTION")
+	*workspace = os.Getenv("DRONE_WORKSPACE")
+	vargs.Token = os.Getenv("GAE_CREDENTIALS") // secrets are not prefixed
+	vargs.Version = os.Getenv("PLUGIN_VERSION")
+	vargs.FlexImage = os.Getenv("PLUGIN_FLEX_IMAGE")
+	vargs.AppFile = os.Getenv("PLUGIN_APP_FILE")
+	vargs.CronFile = os.Getenv("PLUGIN_CRON_FILE")
+	vargs.DispatchFile = os.Getenv("PLUGIN_DISPATCH_FILE")
+	vargs.Dir = os.Getenv("PLUGIN_DIR")
+	vargs.AppCfgCmd = os.Getenv("PLUGIN_APPCFG_CMD")
+	vargs.GCloudCmd = os.Getenv("PLUGIN_GCLOUD_CMD")
 
-	// secrets are not prefixed
-	vargs.Token = os.Getenv("TOKEN")
-
+	// Maps
 	dummyVargs := dummyGAE{}
-
 	addlArgs := os.Getenv("PLUGIN_ADDL_ARGS")
 	if addlArgs != "" {
 		if err := json.Unmarshal([]byte(addlArgs), &dummyVargs.AddlArgs); err != nil {
@@ -203,20 +210,9 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 		vargs.AEEnv = dummyVargs.AEEnv
 	}
 
-	// Pity the fool whose list values include commas
+	// Lists: pity the fool whose values include commas
 	vargs.AddlFlags = strings.Split(os.Getenv("PLUGIN_ADDL_FLAGS"), ",")
 	vargs.SubCommands = strings.Split(os.Getenv("PLUGIN_SUB_COMMANDS"), ",")
-
-	vargs.Version = os.Getenv("PLUGIN_VERSION")
-	vargs.FlexImage = os.Getenv("PLUGIN_FLEX_IMAGE")
-	vargs.AppFile = os.Getenv("PLUGIN_APP_FILE")
-	vargs.CronFile = os.Getenv("PLUGIN_CRON_FILE")
-	vargs.DispatchFile = os.Getenv("PLUGIN_DISPATCH_FILE")
-	vargs.Dir = os.Getenv("PLUGIN_DIR")
-	vargs.AppCfgCmd = os.Getenv("PLUGIN_APPCFG_CMD")
-	vargs.GCloudCmd = os.Getenv("PLUGIN_GCLOUD_CMD")
-
-	*workspace = os.Getenv("DRONE_WORKSPACE")
 
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvInput(t *testing.T) {
+
+	// Ideally we wouldn't be messing with the overall test environment
+	// But I don't see a way to have a go subprocess with its own env
+
+	// Good parameters
+	os.Setenv("DRONE_WORKSPACE", "/dev/null")
+	os.Setenv("PLUGIN_AE_ENVIRONMENT", `{"key1":"value1", "key2":"value2"}`)
+	os.Setenv("PLUGIN_SUB_COMMANDS", "do,this,now,please")
+
+	// Bad parameter
+	os.Setenv("PLUGIN_ADDL_ARGS", "stringthatshouldbejson")
+
+	vargsBad := GAE{}
+	workspaceBad := ""
+	err := configFromEnv(&vargsBad, &workspaceBad)
+	assert.EqualError(t, err, "could not parse param addl_args into a map[string]string")
+
+	// Fix the bad param
+	os.Setenv("PLUGIN_ADDL_ARGS", "")
+
+	vargsGood := GAE{}
+	workspaceGood := ""
+	err = configFromEnv(&vargsGood, &workspaceGood)
+
+	assert.Equal(t, "/dev/null", workspaceGood)
+
+	desiredAEEnv := map[string]string{"key1": "value1", "key2": "value2"}
+	assert.True(t, reflect.DeepEqual(vargsGood.AEEnv, desiredAEEnv))
+
+	desiredSubCommands := []string{"do", "this", "now", "please"}
+	assert.True(t, reflect.DeepEqual(vargsGood.SubCommands, desiredSubCommands))
+
+	// Test unset variable
+	assert.Equal(t, vargsGood.Version, "")
+
+}
+
+func TestValidateVargs(t *testing.T) {
+
+	vargs := GAE{
+		Token:   "mytoken",
+		Project: "myproject",
+		Action:  "dostuff",
+	}
+	assert.NoError(t, validateVargs(&vargs))
+
+	vargs = GAE{
+		Project: "myproject",
+		Action:  "dostuff",
+	}
+	assert.EqualError(t, validateVargs(&vargs), "missing required param: token")
+
+	vargs = GAE{
+		Token:   "mytoken",
+		Project: "myproject",
+	}
+	assert.EqualError(t, validateVargs(&vargs), "missing required param: action")
+
+	vargs = GAE{
+		Token:  "brokentoken",
+		Action: "dostuff",
+	}
+	assert.EqualError(t, validateVargs(&vargs), "project id not found in token or param")
+
+	vargs = GAE{
+		Token:  `{"project_id": "my-gcp-project"}`,
+		Action: "dostuff",
+	}
+	assert.NoError(t, validateVargs(&vargs))
+
+	vargs = GAE{
+		Token:   `{"project_id": "my-gcp-project"}`,
+		Project: "my-other-project",
+		Action:  "dostuff",
+	}
+	assert.NoError(t, validateVargs(&vargs))
+	// Project field overrides token
+	assert.Equal(t, "my-other-project", vargs.Project)
+}
+
+/*
+//This works in regular go, but not under go test for some reason
+//plugin.MustParse() panics due to stdin EOF
+func TestStdinInput(t *testing.T) {
+
+	tmpfile, _ := ioutil.TempFile("", "stdintest")
+	tmpfileName := tmpfile.Name()
+	defer os.Remove(tmpfileName)
+	tmpfile.Write([]byte(`{"workspace":{"path":"/dev/null"}}`))
+	tmpfile.Close()
+
+	fakeStdin, err := os.Open(tmpfileName)
+	if err != nil {
+		t.Error(err)
+	}
+	//os.Stdin.Close()
+	os.Stdin = fakeStdin
+
+	vargs := GAE{}
+	workspace := ""
+	configFromStdin(&vargs, &workspace)
+
+	assert.Equal(t, "/dev/null", workspace)
+}
+*/

--- a/main_test.go
+++ b/main_test.go
@@ -17,33 +17,35 @@ func TestEnvInput(t *testing.T) {
 	os.Setenv("DRONE_WORKSPACE", "/dev/null")
 	os.Setenv("PLUGIN_AE_ENVIRONMENT", `{"key1":"value1", "key2":"value2"}`)
 	os.Setenv("PLUGIN_SUB_COMMANDS", "do,this,now,please")
+	os.Setenv("GAE_CREDENTIALS", "{}")
 
 	// Bad parameter
 	os.Setenv("PLUGIN_ADDL_ARGS", "stringthatshouldbejson")
 
-	vargsBad := GAE{}
-	workspaceBad := ""
-	err := configFromEnv(&vargsBad, &workspaceBad)
+	vargs := GAE{}
+	workspace := ""
+	err := configFromEnv(&vargs, &workspace)
 	assert.EqualError(t, err, "could not parse param addl_args into a map[string]string")
 
 	// Fix the bad param
 	os.Setenv("PLUGIN_ADDL_ARGS", "")
 
-	vargsGood := GAE{}
-	workspaceGood := ""
-	err = configFromEnv(&vargsGood, &workspaceGood)
+	vargs = GAE{}
+	workspace = ""
+	err = configFromEnv(&vargs, &workspace)
 
-	assert.Equal(t, "/dev/null", workspaceGood)
+	assert.Equal(t, "/dev/null", workspace)
+
+	assert.Equal(t, "{}", vargs.Token)
 
 	desiredAEEnv := map[string]string{"key1": "value1", "key2": "value2"}
-	assert.True(t, reflect.DeepEqual(vargsGood.AEEnv, desiredAEEnv))
+	assert.True(t, reflect.DeepEqual(vargs.AEEnv, desiredAEEnv))
 
 	desiredSubCommands := []string{"do", "this", "now", "please"}
-	assert.True(t, reflect.DeepEqual(vargsGood.SubCommands, desiredSubCommands))
+	assert.True(t, reflect.DeepEqual(vargs.SubCommands, desiredSubCommands))
 
 	// Test unset variable
-	assert.Equal(t, vargsGood.Version, "")
-
+	assert.Equal(t, vargs.Version, "")
 }
 
 func TestValidateVargs(t *testing.T) {


### PR DESCRIPTION
Work with Drone 0.6+, while still working with 0.4, but not 0.5 (because it's deprecated, according to the maintainers, and secrets are totally different than the other two).

Tested with `action: update` on:

0.4: https://drone-general-dev.newsdev.net/nytm/jryan-test/15

0.7: https://drone.dv.nyt.net/nytm/jryan-test/17

and added a few unit tests.

I'm not really familiar with all the ways people are using this, so other testing would be appreciated. This is available now on `jrynyt2/drone-gae:latest`