### PR TITLE
remove 'Running Command' logging statement

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -1,14 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"os/exec"
-	"regexp"
-	"strings"
 )
-
-var reRedact = regexp.MustCompile(`(oauth2_access_token)\s+\S+\s+`)
 
 type Environ struct {
 	dir    string
@@ -28,8 +23,6 @@ func NewEnviron(dir string, env []string, stdout, stderr io.Writer) *Environ {
 
 // Run executes the given program.
 func (e *Environ) Run(name string, arg ...string) error {
-	displayArg := reRedact.ReplaceAll([]byte(strings.Trim(fmt.Sprint(arg), "[]")), []byte("$1 [redacted] "))
-	fmt.Printf("Running Command: %s %s\n", name, displayArg)
 	cmd := exec.Command(name, arg...)
 	cmd.Dir = e.dir
 	cmd.Env = e.env


### PR DESCRIPTION
It's leaking env vars into drone logs. 