### PR TITLE
remove `-e` param from docker login command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
     docker build -t "nytimes/drone-gae:latest" .;
-    docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+    docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker push "nytimes/drone-gae:latest";
     fi
-


### PR DESCRIPTION
It's no longer necessary, and the latest travis build failed because of its presence
https://docs.travis-ci.com/user/docker/#Branch-Based-Registry-Pushes

Open `after success` on the docker step in https://travis-ci.org/NYTimes/drone-gae/builds/342502198
```
Successfully tagged nytimes/drone-gae:latest
unknown shorthand flag: 'e' in -e=[secure]
See 'docker login --help'.```