### PR TITLE
expand env vars when passed into appengine vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,8 +228,8 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 		}
 
 		// expand any env vars in template variable values
-		for k := range dummyVargs.TemplateVars {
-			if v, ok := dummyVargs.TemplateVars[k].(string); ok {
+		for k, v := range dummyVargs.TemplateVars {
+			if v, ok := v.(string); ok {
 				if s := os.ExpandEnv(v); s != "" {
 					dummyVargs.TemplateVars[k] = os.ExpandEnv(v)
 				}

--- a/main.go
+++ b/main.go
@@ -226,6 +226,15 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 		if err := json.Unmarshal([]byte(templateVars), &dummyVargs.TemplateVars); err != nil {
 			return fmt.Errorf("could not parse param vars into a map[string]interface{}")
 		}
+
+		// expand any env vars in template variable values
+		for k := range dummyVargs.TemplateVars {
+			if v, ok := dummyVargs.TemplateVars[k].(string); ok {
+				if s := os.ExpandEnv(v); s != "" {
+					dummyVargs.TemplateVars[k] = os.ExpandEnv(v)
+				}
+			}
+		}
 		vargs.TemplateVars = dummyVargs.TemplateVars
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -14,10 +14,13 @@ func TestEnvInput(t *testing.T) {
 	// Ideally we wouldn't be messing with the overall test environment
 	// But I don't see a way to have a go subprocess with its own env
 
+	// test ENV Vars
+	os.Setenv("SECRET_VALUE", "abc123")
+
 	// Good parameters
 	os.Setenv("DRONE_WORKSPACE", "/dev/null")
 	os.Setenv("PLUGIN_AE_ENVIRONMENT", `{"key1":"value1", "key2":"value2"}`)
-	os.Setenv("PLUGIN_VARS", `{"key1":"value1", "key2":"value2"}`)
+	os.Setenv("PLUGIN_VARS", `{"key1":"$SECRET_VALUE", "key2":"value2"}`)
 	os.Setenv("PLUGIN_SUB_COMMANDS", "do,this,now,please")
 	os.Setenv("GAE_CREDENTIALS", "{}")
 
@@ -43,7 +46,7 @@ func TestEnvInput(t *testing.T) {
 	desiredAEEnv := map[string]string{"key1": "value1", "key2": "value2"}
 	assert.True(t, reflect.DeepEqual(vargs.AEEnv, desiredAEEnv))
 
-	desiredTemplateVars := map[string]interface{}{"key1": "value1", "key2": "value2"}
+	desiredTemplateVars := map[string]interface{}{"key1": "abc123", "key2": "value2"}
 	assert.True(t, reflect.DeepEqual(vargs.TemplateVars, desiredTemplateVars))
 
 	desiredSubCommands := []string{"do", "this", "now", "please"}


### PR DESCRIPTION
Drone >0.4 will not expand env vars being passed into `vars`:

In this case, the value of `PASSWORD` in the app.yaml file would be `${PASSWORD}"`. 

.drone.yml
```
    vars:
      PASSWORD: ${PASSWORD}
```

app.yaml:
```
env_variables:
  PASSWORD: {{ .PASSWORD }}

```
This PR expands env vars passed into `vars` so that if one exists for the value it'll be replaced. 