### PR TITLE
build docker image during tests to catch failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - go test
   - go build -ldflags "-s -w -X main.build=$TRAVIS_BUILD_NUMBER -X main.rev=$TRAVIS_COMMIT" -a -tags netgo
   - docker build -t "nytimes/drone-gae:latest" .
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker push "nytimes/drone-gae:latest";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ script:
   - go test
   - go build -ldflags "-s -w -X main.build=$TRAVIS_BUILD_NUMBER -X main.rev=$TRAVIS_COMMIT" -a -tags netgo
   - docker build -t "nytimes/drone-gae:latest" .
-
-after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker push "nytimes/drone-gae:latest";

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 
 go:
-  - 1.7
+  - "1.10"
 
 env:
   - CGO_ENABLED=0
@@ -13,10 +13,10 @@ script:
   - go vet
   - go test
   - go build -ldflags "-s -w -X main.build=$TRAVIS_BUILD_NUMBER -X main.rev=$TRAVIS_COMMIT" -a -tags netgo
+  - docker build -t "nytimes/drone-gae:latest" .
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
-    docker build -t "nytimes/drone-gae:latest" .;
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     docker push "nytimes/drone-gae:latest";
     fi


### PR DESCRIPTION
Travis builds are passing even though docker builds have issues. Build the docker image during testing to verify.

For instance, this build 'passed' but the docker image build failed https://travis-ci.org/NYTimes/drone-gae/builds/352995451

Also update Go to 1.10 in travis. 

This should fail initially, because the GAE SDK isn't available for the version that gcloud is on. 

edit: this is the failure of this PR before a rebase https://travis-ci.org/NYTimes/drone-gae/builds/353014189 