### PR TITLE
Fixing issue with AddlFlags.

### DIFF
--- a/main.go
+++ b/main.go
@@ -322,11 +322,19 @@ func runGcloud(runner *Environ, workspace string, vargs GAE) error {
 	args = append(args, "--quiet")
 
 	// add the remaining arguments
-	for k, v := range vargs.AddlArgs {
-		args = append(args, k, v)
+	if len(vargs.AddlArgs) > 0 {
+		for k, v := range vargs.AddlArgs {
+			args = append(args, k, v)
+		}
 	}
-	for _, v := range vargs.AddlFlags {
-		args = append(args, v)
+
+	// add any additional singleton flags
+	if len(vargs.AddlFlags) > 0 {
+		for _, v := range vargs.AddlFlags {
+			if len(v) > 0 {
+				args = append(args, v)
+			}
+		}
 	}
 
 	if err := setupAppFile(workspace, vargs); err != nil {


### PR DESCRIPTION
When no flags were specified a blank argument would be added.  The AddlFlags were read in from the environment and then split which ends up with an array with ony empty string.  Added safety logic to ensure blank flags will not get added to the argument list