### PR TITLE
using the gcloud sdk base image instead of installing the components ourselves

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,13 @@
-FROM alpine:3.7
+FROM google/cloud-sdk:latest
 
-ENV GOOGLE_CLOUD_SDK_VERSION=223.0.0
+RUN apt-get install -qqu unzip
+
 ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.68
-ENV CLOUDSDK_APP_RUNTIME_ROOT=/google-cloud-sdk/platform/ext-runtime/
-RUN apk add --no-cache curl python
-
-# Install the gcloud SDK
-RUN curl -fsSLo google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GOOGLE_CLOUD_SDK_VERSION-linux-x86_64.tar.gz
-RUN tar -xzf google-cloud-sdk.tar.gz
-RUN rm google-cloud-sdk.tar.gz
-RUN ./google-cloud-sdk/install.sh --quiet
-
-# Install the app engine SDKs
-RUN ./google-cloud-sdk/bin/gcloud components install app-engine-go app-engine-java app-engine-php app-engine-python-extras alpha beta
 
 # Install the legacy app engine SDK
 RUN curl -fsSLo go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip
 RUN unzip -q go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip
 RUN rm go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip
-
-# Clean up
-RUN rm -rf ./google-cloud-sdk/.install
 
 ADD drone-gae /bin/
 ENTRYPOINT ["/bin/drone-gae"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM google/cloud-sdk:latest
+FROM google/cloud-sdk:alpine
 
-RUN apt-get install -qqu unzip
+RUN apk add -U --no-cache unzip
 
 ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.68
 

--- a/main.go
+++ b/main.go
@@ -274,7 +274,7 @@ func validateVargs(vargs *GAE) error {
 	}
 
 	if vargs.GCloudCmd == "" {
-		vargs.GCloudCmd = "/google-cloud-sdk/bin/gcloud"
+		vargs.GCloudCmd = "gcloud"
 	}
 
 	return nil


### PR DESCRIPTION
we've verified appcfg.py still works and this also works with the new go111 runtime.