### PR TITLE
pre-installing the GAE SDK for gcloud to avoid it happening on the fly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM google/cloud-sdk:alpine
+FROM google/cloud-sdk:latest
 
-RUN apk add -U --no-cache unzip
-
-RUN gcloud components install app-engine-go
+RUN apt-get install -qqy unzip
 
 ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.68
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM google/cloud-sdk:alpine
 
 RUN apk add -U --no-cache unzip
 
+RUN gcloud components install app-engine-go
+
 ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.68
 
 # Install the legacy app engine SDK


### PR DESCRIPTION
After comparing image sizes, I found the `latest` image with all components already installed was smaller than the `alpine` image after installing the needed components, so just falling back to `latest`