### PR TITLE
Use alpine base + prune SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM google/cloud-sdk:224.0.0-alpine
 
 RUN apk add -U --no-cache unzip
 
-# Install appengine SDK + prune unnecessary goroots
-RUN gcloud components install app-engine-go \
-		&& rm -rf google-cloud-sdk/platform/google_appengine/goroot-1.9
+# Install appengine SDK
+RUN gcloud components install app-engine-go
+
+# Make sure appcfg is executable
+RUN chmod +x /google-cloud-sdk/platform/google_appengine/appcfg.py
 
 ADD drone-gae /bin/
 ENTRYPOINT ["/bin/drone-gae"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
-FROM google/cloud-sdk:latest
+FROM google/cloud-sdk:224.0.0-alpine
 
-RUN apt-get install -qqy unzip
+RUN apk add -U --no-cache unzip
 
-ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.68
-
-# Install the legacy app engine SDK
-RUN curl -fsSLo go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip
-RUN unzip -q go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip
-RUN rm go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip
+# Install appengine SDK + prune unnecessary goroots
+RUN gcloud components install app-engine-go \
+		&& rm -rf google-cloud-sdk/platform/google_appengine/goroot-1.9
 
 ADD drone-gae /bin/
 ENTRYPOINT ["/bin/drone-gae"]

--- a/main.go
+++ b/main.go
@@ -270,7 +270,7 @@ func validateVargs(vargs *GAE) error {
 	}
 
 	if vargs.AppCfgCmd == "" {
-		vargs.AppCfgCmd = "/go_appengine/appcfg.py"
+		vargs.AppCfgCmd = "/google-cloud-sdk/platform/google_appengine/appcfg.py"
 	}
 
 	if vargs.GCloudCmd == "" {


### PR DESCRIPTION
Updates to help reduce image size:
- Use alpine base + lock to gcloud v224
- Cut secondary SDK installation
- Update AppCfgCmd default to gcloud appengine sdk location

With these changes compressed image size as reported by DockerHub is ~270mb.  I've pushed a copy here for testing: https://hub.docker.com/r/bharanin/drone-gae/ . 

I ran test deployments with standard (go1.9, go111) and flex and they worked as expected - however, if folks could try with a few real-world builds that would be ideal.

Based on appengine release notes (https://cloud.google.com/appengine/docs/standard/go/release-notes) go1.6 and go1.8 deployments are now blocked - so this PR will drop support for those as well.

