### PR TITLE
add service and a way to differentiate between gcloud groups and commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ type GAE struct {
 	// value will be sanitized (lowercase, replace non-alphanumeric with `-`, max 63 chars)
 	Version string `json:"version"`
 	// Service is used to set the service to be deployed
-	// value will be sanitized (lowercase, replace non-alphanumeric with `-`, max 63 chars)
 	Service string `json:"service"`
 	// AEEnv allows users to set additional environment variables with `appcfg.py -E`
 	// in their App Engine environment. This can be useful for injecting

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ type GAE struct {
 	// or to alter existing deployments.
 	// value will be sanitized (lowercase, replace non-alphanumeric with `-`, max 63 chars)
 	Version string `json:"version"`
+	// Service is used to set the service to be deployed
+	// value will be sanitized (lowercase, replace non-alphanumeric with `-`, max 63 chars)
+	Service string `json:"service"`
 	// AEEnv allows users to set additional environment variables with `appcfg.py -E`
 	// in their App Engine environment. This can be useful for injecting
 	// secrets from your Drone secret store. No effect with `gcloud` commands.
@@ -164,8 +167,8 @@ func wrapMain() error {
 		return fmt.Errorf("error: %s\n", err)
 	}
 
-	// if gcloud app cmd, run it
-	if gcloudCmds[vargs.Action] {
+	// if gcloud app cmd or group, run it
+	if gcloudCmds[vargs.Action] || gcloudGroups[vargs.Action] {
 		err = runGcloud(runner, workspace, vargs)
 	} else {
 		// otherwise, do appcfg.py command
@@ -311,11 +314,16 @@ func validateVargs(vargs *GAE) error {
 	return nil
 }
 
-var gcloudCmds = map[string]bool{
-	"deploy":    true,
+// Gcloud Groups
+var gcloudGroups = map[string]bool{
 	"services":  true,
 	"versions":  true,
 	"instances": true,
+}
+
+// Gcloud Commands
+var gcloudCmds = map[string]bool{
+	"deploy": true,
 }
 
 func runGcloud(runner *Environ, workspace string, vargs GAE) error {
@@ -337,8 +345,25 @@ func runGcloud(runner *Environ, workspace string, vargs GAE) error {
 	args = append(args, "./app.yaml")
 
 	// add a version if we've got one
+	// (requires passing args differently based on whether it's a group or plain command)
 	if vargs.Version != "" {
-		args = append(args, "--version", vargs.Version)
+		if gcloudCmds[vargs.Action] {
+			args = append(args, "--version", vargs.Version)
+		} else {
+			// it's a gcloud command for a group, treat it differently
+			args = append(args, vargs.Version)
+		}
+	}
+
+	// add a service if we've got one
+	// (requires passing args differently based on whether it's a group or plain command)
+	if vargs.Service != "" {
+		if gcloudCmds[vargs.Action] {
+			args = append(args, "--service", vargs.Service)
+		} else {
+			// it's a gcloud command for a group, treat it differently
+			args = append(args, vargs.Service)
+		}
 	}
 
 	if vargs.FlexImage != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -117,6 +117,18 @@ func TestValidateVargs(t *testing.T) {
 	}
 	assert.NoError(t, validateVargs(&vargs))
 	assert.Equal(t, "feature-prj-test123", vargs.Version)
+
+	// sanitize version short string
+	vargs = GAE{
+		Token:   "mytoken",
+		Project: "myproject",
+		Action:  "dostuff",
+		Service: "myservice",
+		Version: "version1",
+	}
+	assert.NoError(t, validateVargs(&vargs))
+	assert.Equal(t, "version1", vargs.Version)
+	assert.Equal(t, "myservice", vargs.Service)
 }
 
 func TestSetupFile(t *testing.T) {


### PR DESCRIPTION
This PR adds the service field to be configurable on the gcloud command. It also splits the gcloud commands that respond to group or plain gcloud command because the syntax is different. I wasn't sure how I could write tests for this so any advice/suggestion welcome.

For example:

This is a group gcloud command:
`gcloud app versions delete <service> <version>`

whereas this is a plain gcloud command:
`gcloud app deploy <yml file> --version <version>`  

The group type doesn't support deploying with a yml file.

Here are the gcloud docs for reference:  https://cloud.google.com/sdk/gcloud/reference/app/