### PR TITLE
Redact multiline JSON strings in the output

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var reRedact = regexp.MustCompile(`(?:^|\s+)(-E\s+\S+:|--oauth2_access_token\s+)\S+`)
+var reRedact = regexp.MustCompile(`(?:^|\s+)(-E\s+\S+:|--oauth2_access_token\s+)({[\s\S]*}|\S+)`)
 
 type Environ struct {
 	dir    string

--- a/exec_test.go
+++ b/exec_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +25,11 @@ func TestEnvironRun(t *testing.T) {
 		assert.Equal(t, "hello, ae\n", stdout.String())
 		assert.Equal(t, "", stderr.String())
 	}
+}
+
+func TestRedaction(t *testing.T) {
+	arg := "--oauth2_access_token hello -E CREDENTIALS:{\n \"name\": \"nameVal\", \n \"name\": \n \"nameVal\", \n \"name\": \"nameVal\"\n }"
+	redacted := reRedact.ReplaceAllString(strings.Trim(fmt.Sprint(arg), "[]"), " $1 [redacted]")
+
+	assert.Equal(t, " --oauth2_access_token  [redacted] -E CREDENTIALS: [redacted]", redacted)
 }


### PR DESCRIPTION
Update regex so that in the Drone build output, the multiline JSON key is fully redacted. Previously was only redacting the first word of it. #37 for reference.