### PR TITLE
bumping to the latest SDK versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:latest
 
 RUN apt-get install -qqy unzip
 
-ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.68
+ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.70
 
 # Install the legacy app engine SDK
 RUN curl -fsSLo go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip


### PR DESCRIPTION
This will also force the main SDK to be built with the latest available version, which is not pinned