### PR TITLE
Update cloud-sdk to 276

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:latest
+FROM google/cloud-sdk:276.0.0
 
 RUN apt-get install -qqy unzip
 


### PR DESCRIPTION
app engine SDK is not being updated regularly but we need to keep up
with gcloud sdk versions somehow. Bumping the version of cloud-sdk to
force a new build.

According to [this doc][old] the standalone app engine SDK will not be
available to download as of 2020 July 30. It has been deprecated as of
2019 July 30.

276 is the latest version as of today https://hub.docker.com/r/google/cloud-sdk/tags

[old]: https://cloud.google.com/appengine/docs/standard/python/sdk-gcloud-migration