### PR TITLE
pick up GAE_CREDENTIALS for both drone 1.x and drone 0.x

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,7 +223,12 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 	vargs.Project = os.Getenv("PLUGIN_PROJECT")
 	vargs.Action = os.Getenv("PLUGIN_ACTION")
 	*workspace = os.Getenv("DRONE_WORKSPACE")
-	vargs.Token = os.Getenv("GAE_CREDENTIALS") // secrets are not prefixed
+
+	vargs.Token = os.Getenv("PLUGIN_GAE_CREDENTIALS")
+	if vargs.Token == "" {
+		vargs.Token = os.Getenv("GAE_CREDENTIALS") // falling back to old env variable for drone 0.x compatibility
+	}
+
 	vargs.Version = os.Getenv("PLUGIN_VERSION")
 	vargs.FlexImage = os.Getenv("PLUGIN_FLEX_IMAGE")
 	vargs.AppFile = os.Getenv("PLUGIN_APP_FILE")

--- a/main_test.go
+++ b/main_test.go
@@ -22,7 +22,7 @@ func TestEnvInput(t *testing.T) {
 	os.Setenv("PLUGIN_AE_ENVIRONMENT", `{"key1":"value1", "key2":"value2"}`)
 	os.Setenv("PLUGIN_VARS", `{"key1":"$SECRET_VALUE", "key2":"value2"}`)
 	os.Setenv("PLUGIN_SUB_COMMANDS", "do,this,now,please")
-	os.Setenv("GAE_CREDENTIALS", "{}")
+	os.Setenv("PLUGIN_GAE_CREDENTIALS", "{}")
 
 	// Bad parameter
 	os.Setenv("PLUGIN_ADDL_ARGS", "stringthatshouldbejson")


### PR DESCRIPTION
Still need to amend the docs.