### PR TITLE
Add capability to read env vars from file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/drone/drone-plugin-go v0.0.0-20160112175251-d6109f644c59
+	github.com/joho/godotenv v1.3.0
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/drone/drone-plugin-go v0.0.0-20160112175251-d6109f644c59 h1:lc8w5rGVkaSLxr/Tm92YrFoICHGmstQ31Do9wvuvmt0=
 github.com/drone/drone-plugin-go v0.0.0-20160112175251-d6109f644c59/go.mod h1:PSMBZt7yp90rISzQ1oYaMLKo2lLRE/0uToly1W5MBWk=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/joho/godotenv"
 	"github.com/drone/drone-plugin-go/plugin"
 )
 
@@ -124,6 +125,11 @@ func wrapMain() error {
 
 	vargs := GAE{}
 	workspace := ""
+
+	// If there is an env vars file load it
+	if _, err := os.Stat("/run/drone/env"); err == nil {
+		godotenv.Overload("/run/drone/env")
+	}
 
 	// Check what drone version we're running on
 	if os.Getenv("DRONE_WORKSPACE") == "" { // 0.4

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func wrapMain() error {
 
 	// If there is an env vars file load it
 	if _, err := os.Stat("/run/drone/env"); err == nil {
-		godotenv.Overload("/run/drone/env")
+		godotenv.Load("/run/drone/env")
 	}
 
 	// Check what drone version we're running on


### PR DESCRIPTION
# What
Add [`dotenv`](github.com/joho/godotenv) module and overload environment variables in `/run/drone/env` if that file exists.

# Why
This allows us to store credentials in an environment variables file in a step and pass them to the `drone-gae` step to be used during deploy (e.g use secrets from `Vault` stored on disk in `/run/drone/env`

# How
- Add `github.com/joho/godotenv v1.3.0` to the mod file
- Add a small block to `main.go` that checks whether the file exists and overloads the env vars (inspired by the [Drone Slack plugin](https://github.com/drone-plugins/drone-slack))