### PR TITLE
Do not append yaml file to args if Action is a gcloudGroup

### DIFF
--- a/main.go
+++ b/main.go
@@ -364,14 +364,17 @@ func runGcloud(runner *Environ, workspace string, vargs GAE) error {
 		}
 	}
 
-	switch {
-	// hook in the apropro yaml file
-	case vargs.DispatchFile != "":
-		args = append(args, "./dispatch.yaml")
-	case vargs.CronFile != "":
-		args = append(args, "./cron.yaml")
-	default:
-		args = append(args, "./app.yaml")
+	// hook in the appropriate yaml file unless the action is a group
+	// 'gcloud app services X Y Z' fails with the addition of a yaml file
+	if !gcloudGroups[vargs.Action] {
+		switch {
+		case vargs.DispatchFile != "":
+			args = append(args, "./dispatch.yaml")
+		case vargs.CronFile != "":
+			args = append(args, "./cron.yaml")
+		default:
+			args = append(args, "./app.yaml")
+		}
 	}
 
 	// add a version if we've got one


### PR DESCRIPTION
Actions like `gcloud app services list` will fail with the addition of a
yaml file argument because it's arbitrary and unnecessary.


Use case:
I am trying to use `gcloud app services set-traffic` but I see the error:
```
ERROR: (gcloud.app.services.list) unrecognized arguments: ./app.yaml 
```

The command is configured properly with the exception of the `app.yaml` arg:
```
Running Command: gcloud app services set-traffic ./app.yaml MY_SERVICE --project MY_PROJECT --quiet --migrate --splits MY_COMMIT_SHA=1
```

Drone step is setup as follows:
```
- name: migrate-traffic
  pull: if-not-exists
  image: nytimes/drone-gae
  settings:
    action: services
    sub_commands: set-traffic
    addl_flags:
    - --migrate
    - --splits ${DRONE_COMMIT_SHA:0:8}=1
    project: MY_PROJECT
    service: MY_SERVICE
  environment:
    GAE_CREDENTIALS:
      from_secret: MY_CREDENTIALS
  when:
    event:
    - tag
```

None of the help docs for the commands in [`gcloudGroup`](https://github.com/nytimes/drone-gae/blob/master/main.go#L334) point to the use of a yaml file so this should not break anything.
```
$ gcloud help app services
$ gcloud help app instances
$ gcloud help app versions
```