### PR TITLE
Update cloud-sdk to 328.0.0 and move to gcr-hosted image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:276.0.0
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:328.0.0
 
 RUN apt-get install -qqy unzip
 


### PR DESCRIPTION
Google will not be hosting cloud-sdk on docker hub after March 2021.

Also fixes the Drone build issue on main branch https://cloud.drone.io/nytimes/drone-gae/80/1/4 

https://hub.docker.com/r/google/cloud-sdk
> The Google Cloud SDK Docker image will cease being hosted on Docker Hub in March 2021. To continue using the Cloud SDK Docker Image, please use the image hosted on Google Container Registry by following the instructions located on the image's documentation page or GitHub page.

https://github.com/GoogleCloudPlatform/cloud-sdk-docker/releases
https://cloud.google.com/sdk/docs/downloads-docker