### PR TITLE
Enable service account keys to be provided in base64

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -12,6 +12,8 @@ Refer to GAE [Access Control](https://cloud.google.com/appengine/docs/flexible/p
 Use least permissible role for the tasks required.
 Typically for `action: deploy` this is `App Engine Admin` and `Cloud Build Service Account`.
 
+If the service account JSON key is provided in base64 format, the plugin will decode it internally.
+
 For example:
 
 ```yml

--- a/main.go
+++ b/main.go
@@ -248,6 +248,8 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 	if decodedToken, err := base64.StdEncoding.DecodeString(vargs.Token); err == nil {
 		// if no error then the token is base64 encoded (or empty)
 		vargs.Token = string(decodedToken)
+	} else {
+		fmt.Println("gae_credentials is not base64 encoded: skipping decode")
 	}
 
 	// Maps

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -242,6 +243,11 @@ func configFromEnv(vargs *GAE, workspace *string) error {
 		// falling back to old env variable for drone 0.x compatibility
 		// secrets are not prefixed
 		vargs.Token = os.Getenv("GAE_CREDENTIALS")
+	}
+
+	if decodedToken, err := base64.StdEncoding.DecodeString(vargs.Token); err == nil {
+		// if no error then the token is base64 encoded (or empty)
+		vargs.Token = string(decodedToken)
 	}
 
 	// Maps

--- a/main_test.go
+++ b/main_test.go
@@ -229,3 +229,22 @@ func TestSetupFile(t *testing.T) {
 	}
 
 }
+
+func TestEncodedToken(t *testing.T) {
+
+	os.Setenv("PLUGIN_GAE_CREDENTIALS", "ZW5jb2RlZCBzZXJ2aWNlIGFjY291bnQga2V5")
+
+	vargs := GAE{}
+
+	workspace := ""
+	configFromEnv(&vargs, &workspace)
+
+	expectedDecodedToken := "encoded service account key"
+	assert.Equal(t, expectedDecodedToken, vargs.Token)
+
+	nonEncodedToken := "non-encoded service account key"
+	os.Setenv("PLUGIN_GAE_CREDENTIALS", nonEncodedToken)
+
+	configFromEnv(&vargs, &workspace)
+	assert.Equal(t, nonEncodedToken, vargs.Token)
+}


### PR DESCRIPTION
We'd like to have Drone secrets in base64 to be passed directly to the `GAE_CREDENTIALS` param.

The main use case is to integrate directly with the [Vault Google Cloud Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp#service-account-keys) that returns the service account key in base64.

Example:

```
---
kind: secret
name: google_credentials_b64
get:
  path: gcp/key/drone-gae-deployer
  name: private_key_data

---
kind: pipeline
name: default
steps:
[...]
- name: deploy
  pull: if-not-exists
  image: nytimes/drone-gae
  settings:
    action: deploy
    app_file: app.yaml
    max_versions: 2
    project: some-project
    version: ${DRONE_COMMIT}
    gae_credentials:
      from_secret: google_credentials_b64
```