### PR TITLE
Revert "updated Cloud and App Engine SDK versions. (#71)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:395.0.0
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:328.0.0
 
 RUN apt-get install -qqy unzip
 
-ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.94
+ENV GOOGLE_APP_ENGINE_SDK_VERSION=1.9.70
 
 # Install the legacy app engine SDK
 RUN curl -fsSLo go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-$GOOGLE_APP_ENGINE_SDK_VERSION.zip


### PR DESCRIPTION
This reverts commit 748d2a31b5580d41454491c5be37d54a942b1de5.

@nyt-hughmandeville it seems like this version does not exist: https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.94.zip
