### PR TITLE
Update base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:328.0.0
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:419.0.0
 
 RUN apt-get install -qqy unzip
 


### PR DESCRIPTION
<!--
Hi there,

Thank you for opening a pull request, we will get back to you as soon as possible!
-->

Did you update the tests?
- [ ] yes
- [ ] no
- [x] n/a

Did you update the docs?
- [ ] yes
- [ ] no
- [x] n/a

The [cooking grocery lists](https://github.com/nytimes/cooking-grocery-lists) service is a GAE app that until recently ran on go v1.16. Yesterday I found out that GAE [no longer supports go v1.16 at all](https://cloud.google.com/appengine/docs/flexible/go/runtime#go_versions), and requires restructuring our repo a little bit to accommodate other changes to upgrade to v1.18. Our other option is to downgrade to v1.15 👎

Using v1.18 is in preview mode and requires gcloud cli version 417.0.1 or later
