### PR TITLE
Revert "Update base docker image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:419.0.0
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:328.0.0
 
 RUN apt-get install -qqy unzip
 


### PR DESCRIPTION
Reverts nytimes/drone-gae#86

The upgrade of the GCP cloud-sdk base image has caused backwards incompatibility with users using `appcfg.py`, even though that is no longer supported.

For it to be released, it should be tested and we may have to tag a new major version of the plugin.