### PR TITLE
Revert "Bump slackapi/slack-github-action from 1.27.0 to 2.0.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
   
     - name: Slack notification
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@v1.27.0
       if: ${{ github.event_name != 'pull_request' }}
       with:
         payload: |


### PR DESCRIPTION
Reverts nytimes/drone-gae#108

Breaking changes